### PR TITLE
rename k14s to Carvel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-LAB - Getting started with Kubernetes Tools (k14s)
+LAB - Getting started with Carvel
 =====================
 
 TODO: 

--- a/resources/workshop.yaml
+++ b/resources/workshop.yaml
@@ -3,8 +3,8 @@ kind: Workshop
 metadata:
   name: lab-getting-started-k14s
 spec:
-  title: Getting started with Kubernetes Tools (k14s)
-  description: Introducing k14s (Kubernetes Tools), a simple and Composable Tools for Application Deployment
+  title: Getting started with Carvel
+  description: Introducing Carvel, Simple and Composable Tools for Application Deployment
   vendor: eduk8s.io
   authors:
   - eduk8s team

--- a/workshop/content/exercises/2-access-the-application.md
+++ b/workshop/content/exercises/2-access-the-application.md
@@ -6,7 +6,7 @@ kubectl port-forward svc/simple-app 8080:8080
 
 One downside to the kubectl command above: it has to be restarted if the application pod is recreated.
 
-Alternatively, you could use [k14s' kwt tool](https://github.com/k14s/kwt) which exposes cluster IP subnets and cluster DNS to your machine. This way, you can access the application without requiring any restarts.
+Alternatively, you could use [Carvel's kwt tool](https://github.com/k14s/kwt) which exposes cluster IP subnets and cluster DNS to your machine. This way, you can access the application without requiring any restarts.
 
 With kwt installed, run the following command
 

--- a/workshop/content/exercises/4-templating-app-configuration.md
+++ b/workshop/content/exercises/4-templating-app-configuration.md
@@ -17,7 +17,7 @@ Above snippet tells ytt that `HELLO_MSG` environment variable value should be se
 Let's chain ytt and kapp to deploy an update, and note `-v` flag which sets hello_msg value:
 
 ```execute-1
-ytt template -f config-step-2-template/ -v hello_msg="k14s user" | kapp deploy -a simple-app -f- --diff-changes --yes
+ytt template -f config-step-2-template/ -v hello_msg="carvel user" | kapp deploy -a simple-app -f- --diff-changes --yes
 ```
 
 ```
@@ -25,7 +25,7 @@ ytt template -f config-step-2-template/ -v hello_msg="k14s user" | kapp deploy -
   ...
  29, 29           - name: HELLO_MSG
  30     -           value: somebody
-     30 +           value: k14s user
+     30 +           value: carvel user
  31, 31           image: quay.io/eduk8s-labs/sample-app-go@sha256:5021a23e0c4a4633bfd6c95b13898cffb88a0e67f109d87ec01b4f896f4b4296
  32, 32           name: simple-app
 

--- a/workshop/content/exercises/5-patching-app-configuration.md
+++ b/workshop/content/exercises/5-patching-app-configuration.md
@@ -3,7 +3,7 @@ ytt also offers another way to customize application configuration. Instead of r
 For example, our simple app configuration templates do not make Deployment's `spec.replicas` configurable as a data value to control how may Pods are running. Instead of asking authors of simple app to expose a new data value, we can create an overlay file `config-step-2a-overlays/custom-scale.yml` that changes `spec.replicas` to a new value.
 
 ```execute-1
-ytt template -f config-step-2-template/ -f config-step-2a-overlays/custom-scale.yml -v hello_msg="k14s user" | kapp deploy -a simple-app -f- --diff-changes --yes
+ytt template -f config-step-2-template/ -f config-step-2a-overlays/custom-scale.yml -v hello_msg="carvel user" | kapp deploy -a simple-app -f- --diff-changes --yes
 ```
 
 ```

--- a/workshop/content/exercises/6-building-container-images-locally.md
+++ b/workshop/content/exercises/6-building-container-images-locally.md
@@ -21,7 +21,7 @@ __NOTE__: As we're using a real cluster, just read on but you may have to wait u
 Let's insert kbld between ytt and kapp so that images used in our configuration are built before they are deployed by kapp:
 
 ```execute-1
-ytt template -f config-step-3-build-local/ -v hello_msg="k14s user" | kbld -f- | kapp deploy -a simple-app -f- --diff-changes --yes
+ytt template -f config-step-3-build-local/ -v hello_msg="carvel user" | kbld -f- | kapp deploy -a simple-app -f- --diff-changes --yes
 ```
 
 ```
@@ -89,7 +89,7 @@ resolve | final: quay.io/eduk8s-labs/sample-app-go -> kbld:quay-io-eduk8s-labs-s
  17, 25     selector:
  18, 26       matchLabels:
   ...
- 31, 39             value: k14s user
+ 31, 39             value: carvel user
  32     -         image: quay.io/eduk8s-labs/sample-app-go@sha256:5021a23e0c4a4633bfd6c95b13898cffb88a0e67f109d87ec01b4f896f4b4296
      40 +         image: kbld:quay-io-eduk8s-labs-sample-app-go-sha256-03eb944c407c455f8966623ed600f157c23633577d02e51a6763ba1dd546e471
  33, 41           name: simple-app

--- a/workshop/content/exercises/7-pushing-images-to-a-registry.md
+++ b/workshop/content/exercises/7-pushing-images-to-a-registry.md
@@ -13,7 +13,7 @@ kubectl create secret generic registry-credentials --from-file=.dockerconfigjson
 Now 
 
 ```execute-1
-ytt template -f config-step-4-build-and-push/ -v hello_msg="k14s user" -v push_images=true -v push_images_repo={{ REGISTRY_HOST }}/k14s/sample-app-go | kbld -f- | kapp deploy -a simple-app -f- --diff-changes --yes
+ytt template -f config-step-4-build-and-push/ -v hello_msg="carvel user" -v push_images=true -v push_images_repo={{ REGISTRY_HOST }}/carvel/sample-app-go | kbld -f- | kapp deploy -a simple-app -f- --diff-changes --yes
 ```
 
 ```
@@ -27,7 +27,7 @@ quay.io/eduk8s-labs/sample-app-go | finished push (using Docker)
 resolve | final: quay.io/eduk8s-labs/sample-app-go -> index.quay.io/eduk8s-labs/sample-app-go@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
 --- update deployment/simple-app (apps/v1) namespace: default
   ...
- 30, 30             value: k14s user
+ 30, 30             value: carvel user
  31     -         image: kbld:docker-io-dkalinin-k8s-simple-app-sha256-f999be3e0d96c78dc4d4c8330c8de8aff3c91f5e152f021d01cb3cd0e92a1797
      31 +         image: index.docker.io/your-username/your-repo@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
  32, 32           name: simple-app
@@ -53,7 +53,7 @@ kapp inspect -a simple-app --raw --filter-kind Deployment --tty=false | kbld ins
 ```
 Images
 
-Image     {{ REGISTRY_HOST }}/k14s/sample-app-go@sha256:c293f506529ee65e1f6c3600398d29b7677c5fa80c065f60354486dee28cb51a
+Image     {{ REGISTRY_HOST }}/carvel/sample-app-go@sha256:c293f506529ee65e1f6c3600398d29b7677c5fa80c065f60354486dee28cb51a
 Metadata  - Path: /home/eduk8s/exercises/sample-app-go
             Type: local
           - Dirty: true
@@ -67,6 +67,6 @@ Resource  deployment/simple-app (apps/v1) namespace: lab-getting-started-k14s-w0
 Succeeded
 ```
 
-As a benefit of using __kbld__, you will see that image digest reference (e.g. {{ REGISTRY_HOST }}/k14s/sample-app-go@sha256:4c8b96...) was used instead of a tagged reference (e.g. kbld:docker-io...). 
+As a benefit of using __kbld__, you will see that image digest reference (e.g. {{ REGISTRY_HOST }}/carvel/sample-app-go@sha256:4c8b96...) was used instead of a tagged reference (e.g. kbld:docker-io...).
 
 Digest references are preferred to other image reference forms as they are `immutable`, hence provide a gurantee that exact version of built software will be deployed.

--- a/workshop/content/setup-environment.md
+++ b/workshop/content/setup-environment.md
@@ -9,7 +9,7 @@ kubectl version
 
 __NOTE__: Did you type the command in yourself? If you did, click on the command instead and you will find that it is executed for you. You can click on any command which has the <span class="fas fa-running"></span> icon shown to the right of it, and it will be copied to the interactive terminal and run. If you would rather make a copy of the command so you can paste it to another window, hold down the shift key when you click on the command.
 
-* __Install k14s tools by following instructions on [https://k14s.io/](https://k14s.io/)__ In this environment we have already installed the tools and they are available in the PATH.
+* __Install Carvel tools by following instructions on [https://carvel.dev/](https://carvel.dev/)__ In this environment we have already installed the tools and they are available in the PATH.
 
 ```execute
 ytt --version

--- a/workshop/content/workshop-overview.md
+++ b/workshop/content/workshop-overview.md
@@ -1,4 +1,4 @@
-The [k14s](https://k14s.io/) (stands for "Kubernetes Tools") Github organization ([https://github.com/k14s](https://github.com/k14s)) contains several tools we created as a result of working with complex, multi-purpose tools like [Helm](https://helm.sh/). We believe that working with simple, single-purpose tools that easily interoperate with one another results in a better, workflow compared to the all-in-one approach chosen by Helm. We have found this approach to be easier to understand and debug.
+[Carvel](https://carvel.dev/) contains several tools we created as a result of working with complex, multi-purpose tools like [Helm](https://helm.sh/). We believe that working with simple, single-purpose tools that easily interoperate with one another results in a better, workflow compared to the all-in-one approach chosen by Helm. We have found this approach to be easier to understand and debug.
 
 In this workshop we will focus on local application development workflow; however, tools introduced here work also well for other workflows, for example, for production GitOps deployments or manual application deploys. We plan to publish additional blog posts for other workflows. Let us know what you are most interested in!
 
@@ -10,7 +10,7 @@ We break down local application development workflow into the following stages:
 1. Deployment (e.g. kubectl apply ...)
 1. Repeat!
 
-Helm arguably tries to address stages 2, 3, and 4, with configuration, packaging and deployment together in one tool. The community has varied opinions on [advantages](https://medium.com/@aevitas/drastically-improve-your-kubernetes-deployments-with-helm-5323e7f11ef8) and [disadvantages](https://medium.com/@slynko/experiences-with-upgrading-using-helm-b23dc0ca683d?_branch_match_id=494645732166043546) of using Helm. However, let's explore an alternative approach with tools from k14s.
+Helm arguably tries to address stages 2, 3, and 4, with configuration, packaging and deployment together in one tool. The community has varied opinions on [advantages](https://medium.com/@aevitas/drastically-improve-your-kubernetes-deployments-with-helm-5323e7f11ef8) and [disadvantages](https://medium.com/@slynko/experiences-with-upgrading-using-helm-b23dc0ca683d?_branch_match_id=494645732166043546) of using Helm. However, let's explore an alternative approach with Carvel.
 
 For each stage, we have open sourced a tool that we believe addresses that stage's challenges (sections below explore each tool in detail):
 

--- a/workshop/content/workshop-summary.md
+++ b/workshop/content/workshop-summary.md
@@ -1,4 +1,4 @@
-We've seen how [ytt](https://get-ytt.io/), [kbld](https://get-kbld.io/) and [kapp](https://get-kapp.io/) can be used together (`ytt ... | kbld -f- | kapp deploy ...`) to deploy and iterate on an application running on Kubernetes. Each one of these tools has been designed to be single-purpose and composable with other tools from k14s org and larger k8s ecosystem.
+We've seen how [ytt](https://get-ytt.io/), [kbld](https://get-kbld.io/) and [kapp](https://get-kapp.io/) can be used together (`ytt ... | kbld -f- | kapp deploy ...`) to deploy and iterate on an application running on Kubernetes. Each one of these tools has been designed to be single-purpose and composable with other tools from Carvel and larger k8s ecosystem.
 
 We are eager to hear your thoughts and feedback in [#k14s in Kubernetes slack](https://slack.kubernetes.io/) and/or via Github issues and PRs ([https://github.com/k14s/](https://github.com/k14s/)) for each project. Don't hesitate to reach out!
 

--- a/workshop/workshop.yaml
+++ b/workshop/workshop.yaml
@@ -1,4 +1,4 @@
-name: Getting started with k14s
+name: Getting started with Carvel
 
 modules:
     activate:


### PR DESCRIPTION
this PR renames k14s in text copy to Carvel. 

Questions:
- how do we go about renaming repo to lab-getting-started-with-carvel?
- how do we go about renaming registry urls?
- how do we go about renaming a slug "lab-getting-started-k14s"?
  - can we have something shorter so that namespace is short as well (e.g. "carvel")